### PR TITLE
feat: pass `scope` as `this` in `withLock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const scope = {}; // can be a reference to any object you like
 const startTime = Date.now();
 
 async function doSomething(index: number): number {
-    return await withLock(scope, "myKey", async function () {
+    return await withLock(scope, "myKey", async () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
         console.log("index:", index, "time:", Date.now() - startTime);
         return 42;
@@ -49,17 +49,20 @@ const res = await Promise.all([
 console.log(res); // [42, 42, 42]
 ```
 
-You can use the `scope` as `this` in the callback, it will also understand the `this` type if you use TypeScript.
+
+The given `scope` is used as the callback's `this`, so you can use its value in a `function`:
 
 ```typescript
 import {withLock} from "lifecycle-utils";
-const scope = {name: 'Tommy'}; // can be a reference to any object you like
 
-const res = await withLock(scope, "lock", async function () {
+const scope = {userName: "Joe"}; // can be a reference to any object you like
+
+const res = await withLock(scope, "myKey", async function () {
     await new Promise(resolve => setTimeout(resolve, 1000));
-    return `hello ${this.name}!`;
+    return `Hello ${this.userName}`;
 });
-console.log(res); // hello Tommy!
+
+console.log(res); // Hello Joe
 ```
 
 ### `isLockActive`

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ const res = await Promise.all([
     doSomething(3)
 ]);
 
-// index: 1 time: 1000
-// index: 2 time: 2000
-// index: 3 time: 3000
+// index: 1 time: 1000, name: Tommy
+// index: 2 time: 2000, name: Tommy
+// index: 3 time: 3000, name: Tommy
 
 console.log(res); // [42, 42, 42]
 ```

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Calling `withLock` with the same `scope` and `key` will ensure that the callback
 ```typescript
 import {withLock} from "lifecycle-utils";
 
-const scope = {name: 'Tommy'}; // can be a reference to any object you like
+const scope = {}; // can be a reference to any object you like
 const startTime = Date.now();
 
 async function doSomething(index: number): number {
     return await withLock(scope, "myKey", async function () {
         await new Promise(resolve => setTimeout(resolve, 1000));
-        console.log("index:", index, "time:", Date.now() - startTime, "name:", this.name);
+        console.log("index:", index, "time:", Date.now() - startTime);
         return 42;
     });
 }
@@ -42,11 +42,24 @@ const res = await Promise.all([
     doSomething(3)
 ]);
 
-// index: 1 time: 1000, name: Tommy
-// index: 2 time: 2000, name: Tommy
-// index: 3 time: 3000, name: Tommy
+// index: 1 time: 1000
+// index: 2 time: 2000
+// index: 3 time: 3000
 
 console.log(res); // [42, 42, 42]
+```
+
+You can use the `scope` as `this` in the callback, it will also understand the `this` type if you use TypeScript.
+
+```typescript
+import {withLock} from "lifecycle-utils";
+const scope = {name: 'Tommy'}; // can be a reference to any object you like
+
+const res = await withLock(scope, "lock", async function () {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    return `hello ${this.name}!`;
+});
+console.log(res); // hello Tommy!
 ```
 
 ### `isLockActive`

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Calling `withLock` with the same `scope` and `key` will ensure that the callback
 ```typescript
 import {withLock} from "lifecycle-utils";
 
-const scope = {}; // can be a reference to any object you like
+const scope = {name: 'Tommy'}; // can be a reference to any object you like
 const startTime = Date.now();
 
 async function doSomething(index: number): number {
-    return await withLock(scope, "myKey", async () => {
+    return await withLock(scope, "myKey", async function () {
         await new Promise(resolve => setTimeout(resolve, 1000));
-        console.log("index:", index, "time:", Date.now() - startTime);
+        console.log("index:", index, "time:", Date.now() - startTime, "name:", this.name);
         return 42;
     });
 }

--- a/src/withLock.ts
+++ b/src/withLock.ts
@@ -3,11 +3,11 @@ const locks = new Map<any, Map<string, Promise<any>>>();
 /**
  * Only allow one instance of the callback to run at a time for a given `scope` and `key`.
  */
-export async function withLock<ReturnType, ScopeType>(scope: ScopeType, key: string, callback: (this: ScopeType) => Promise<ReturnType>): Promise<ReturnType>;
-export async function withLock<ReturnType, ScopeType>(
+export async function withLock<ReturnType, const ScopeType = any>(scope: ScopeType, key: string, callback: (this: ScopeType) => Promise<ReturnType>): Promise<ReturnType>;
+export async function withLock<ReturnType, const ScopeType = any>(
     scope: ScopeType, key: string, acquireLockSignal: AbortSignal | undefined, callback: (this: ScopeType) => Promise<ReturnType>
 ): Promise<ReturnType>;
-export async function withLock<ReturnType, ScopeType>(
+export async function withLock<ReturnType, const ScopeType = any>(
     scope: ScopeType,
     key: string,
     acquireLockSignalOrCallback: AbortSignal | undefined | ((this: ScopeType) => Promise<ReturnType>),

--- a/src/withLock.ts
+++ b/src/withLock.ts
@@ -3,7 +3,9 @@ const locks = new Map<any, Map<string, Promise<any>>>();
 /**
  * Only allow one instance of the callback to run at a time for a given `scope` and `key`.
  */
-export async function withLock<ReturnType, const ScopeType = any>(scope: ScopeType, key: string, callback: (this: ScopeType) => Promise<ReturnType>): Promise<ReturnType>;
+export async function withLock<ReturnType, const ScopeType = any>(
+    scope: ScopeType, key: string, callback: (this: ScopeType) => Promise<ReturnType>
+): Promise<ReturnType>;
 export async function withLock<ReturnType, const ScopeType = any>(
     scope: ScopeType, key: string, acquireLockSignal: AbortSignal | undefined, callback: (this: ScopeType) => Promise<ReturnType>
 ): Promise<ReturnType>;

--- a/src/withLock.ts
+++ b/src/withLock.ts
@@ -3,14 +3,14 @@ const locks = new Map<any, Map<string, Promise<any>>>();
 /**
  * Only allow one instance of the callback to run at a time for a given `scope` and `key`.
  */
-export async function withLock<ReturnType>(scope: any, key: string, callback: () => Promise<ReturnType>): Promise<ReturnType>;
-export async function withLock<ReturnType>(
-    scope: any, key: string, acquireLockSignal: AbortSignal | undefined, callback: () => Promise<ReturnType>
+export async function withLock<ReturnType, ScopeType>(scope: ScopeType, key: string, callback: (this: ScopeType) => Promise<ReturnType>): Promise<ReturnType>;
+export async function withLock<ReturnType, ScopeType>(
+    scope: ScopeType, key: string, acquireLockSignal: AbortSignal | undefined, callback: (this: ScopeType) => Promise<ReturnType>
 ): Promise<ReturnType>;
-export async function withLock<ReturnType>(
-    scope: any,
+export async function withLock<ReturnType, ScopeType>(
+    scope: ScopeType,
     key: string,
-    acquireLockSignalOrCallback: AbortSignal | undefined | (() => Promise<ReturnType>),
+    acquireLockSignalOrCallback: AbortSignal | undefined | ((this: ScopeType) => Promise<ReturnType>),
     callback?: () => Promise<ReturnType>
 ): Promise<ReturnType> {
     let acquireLockSignal: AbortSignal | undefined = undefined;
@@ -47,7 +47,7 @@ export async function withLock<ReturnType>(
             throw acquireLockSignal.reason;
     }
 
-    const promise = callback();
+    const promise = callback.call(scope);
 
     if (!locks.has(scope))
         locks.set(scope, new Map());

--- a/test/withLock.test.ts
+++ b/test/withLock.test.ts
@@ -300,6 +300,18 @@ describe("withLock", () => {
             // do nothing
         }
     });
+
+    test("this scope works", async () => {
+        const scope = {data: 1};
+        const key = "key";
+
+        let calls = 0;
+        await withLock(scope, key, async function (){
+            expect(this).toBe(scope);
+            calls++;
+        });
+        expect(calls).toBe(1);
+    });
 });
 
 


### PR DESCRIPTION
### Description of change
* feat: pass `scope` as `this` in `withLock`

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [CONTRIBUTING.md](https://github.com/giladgd/lifecycle-utils/blob/master/CONTRIBUTING.md) (PRs that do not follow this convention will not be merged)
